### PR TITLE
Simplify serial port logic, improve the handling of ?, allow the pendant to be turned on and off at will

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,10 +9,6 @@ async function main() {
     const PROXY_PORT = 9999;
 
     const pendant = new PendantDevice();
-    pendant.on('error', (err: any) => {
-        console.error(err);
-        process.exit(1);
-    });
 
     const target = new SerialProxyTarget(SERIAL_PORT);
     const proxy = new ProxyProvider(target, PROXY_PORT, PROXY_IP);

--- a/interposer/proxy.ts
+++ b/interposer/proxy.ts
@@ -176,7 +176,6 @@ export class ProxyProvider extends EventEmitter {
     private clientDataHandler(data: Buffer) {
         this.target.send(data);
         this.clientDataBuffer += data.toString('utf-8');
-        console.log(this.clientDataBuffer);
         for (;;) {
             const match = /[?\n]/.exec(this.clientDataBuffer);
             if (!match) {

--- a/interposer/proxy.ts
+++ b/interposer/proxy.ts
@@ -176,13 +176,17 @@ export class ProxyProvider extends EventEmitter {
     private clientDataHandler(data: Buffer) {
         this.target.send(data);
         this.clientDataBuffer += data.toString('utf-8');
-        let newLine: number;
-        while ((newLine = this.clientDataBuffer.indexOf('\n')) >= 0) {
-            const cmd = this.clientDataBuffer.substring(0, newLine).trim();
+        console.log(this.clientDataBuffer);
+        for (;;) {
+            const match = /[?\n]/.exec(this.clientDataBuffer);
+            if (!match) {
+                break;
+            }
+            const cmd = this.clientDataBuffer.substring(0, match.index + 1).trim();
             if (cmd === '?') {
                 this.lastQuestionTime = Date.now();
             }
-            this.clientDataBuffer = this.clientDataBuffer.substring(newLine + 1);
+            this.clientDataBuffer = this.clientDataBuffer.substring(match.index + 1);
         }
     }
 

--- a/interposer/proxy.ts
+++ b/interposer/proxy.ts
@@ -176,7 +176,7 @@ export class ProxyProvider extends EventEmitter {
         this.clientDataBuffer += data.toString('utf-8');
         let newLine: number;
         while ((newLine = this.clientDataBuffer.indexOf('\n')) >= 0) {
-            let cmd = this.clientDataBuffer.substring(0, newLine).trim();
+            const cmd = this.clientDataBuffer.substring(0, newLine).trim();
             if (cmd === '?') {
                 this.lastQuestionTime = Date.now();
             }
@@ -189,7 +189,7 @@ export class ProxyProvider extends EventEmitter {
         this.deviceDataBuffer += data.toString('utf-8');
         let newLine: number;
         while ((newLine = this.deviceDataBuffer.indexOf('\n')) >= 0) {
-            let respone = this.deviceDataBuffer.substring(0, newLine).trim();
+            const respone = this.deviceDataBuffer.substring(0, newLine).trim();
             if (respone.startsWith('<') && respone.endsWith('>')) {
                 const parsedResponse = StatusReport.parse(respone);
                 this.emit('status', parsedResponse);


### PR DESCRIPTION
- Simplify serial port handling: use DelimiterParser('\n') instead of having application-level logic.
- Allow the pendant to be off at startup and to be turned on and off at any time with no ill effects.
- Improve the handling of ? commands as issued by Carvera Controller (no trailing newline).